### PR TITLE
初回ユーザー登録・生活環境情報登録APIの呼び出し処理

### DIFF
--- a/lib/constants/app_config.dart
+++ b/lib/constants/app_config.dart
@@ -6,6 +6,11 @@ class AppConfig {
   static const String meEndpoint = '/auth/me';
   static const String tokenEndpoint = '/auth/token';
   static const String appEndpoint = '/app/authed';
+
+  // 初回ユーザー登録
+  static const String userRegisterEndpoint = '/app/user/register';
+  // 生活環境情報の登録（初回）
+  static const String userLifestyleEndpoint = '/app/user/lifestyle';
 }
 
 // モックのAPIレスポンスを定義

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -136,7 +136,7 @@ class _MyAppState extends State<MyApp> {
 
                 final userInfo = snapshot.data!;
 
-                return const LoginSplashScreen();
+                return LoginSplashScreen();
               },
             );
           }

--- a/lib/models/user_lifestyle_info.dart
+++ b/lib/models/user_lifestyle_info.dart
@@ -1,0 +1,52 @@
+/// 生活環境情報（初回登録用）
+class UserLifestyleInfo {
+  /// 一人暮らしかどうか
+  final bool isAlone;
+
+  /// 洗濯機の有無
+  final bool hasWasher;
+
+  /// 掃除機の有無
+  final bool hasVacuum;
+
+  /// ロボット掃除機の有無
+  final bool hasRobot;
+
+  /// 食器を使うかどうか
+  final bool useTableware;
+
+  /// 食洗機の有無
+  final bool hasDishwasher;
+
+  UserLifestyleInfo({
+    required this.isAlone,
+    required this.hasWasher,
+    required this.hasVacuum,
+    required this.hasRobot,
+    required this.useTableware,
+    required this.hasDishwasher,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      'isAlone': isAlone,
+      'hasWasher': hasWasher,
+      'hasVacuum': hasVacuum,
+      'hasRobot': hasRobot,
+      'useTableware': useTableware,
+      'hasDishwasher': hasDishwasher,
+    };
+  }
+
+  /// JSON → UserLifestyleInfo
+  factory UserLifestyleInfo.fromJson(Map<String, dynamic> json) {
+    return UserLifestyleInfo(
+      isAlone: json['isAlone'] ?? false,
+      hasWasher: json['hasWasher'] ?? false,
+      hasVacuum: json['hasVacuum'] ?? false,
+      hasRobot: json['hasRobot'] ?? false,
+      useTableware: json['useTableware'] ?? false,
+      hasDishwasher: json['hasDishwasher'] ?? false,
+    );
+  }
+}

--- a/lib/models/user_register_info.dart
+++ b/lib/models/user_register_info.dart
@@ -1,0 +1,45 @@
+/// 初回ユーザー登録のリクエスト情報
+class UserRegisterRequest {
+  /// 誕生日（UNIXタイムスタンプ）
+  final int birthDate;
+
+  /// 居住形態（例: alone, family など）
+  final String livingType;
+
+  UserRegisterRequest({
+    required this.birthDate,
+    required this.livingType,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      'birthDate': birthDate,
+      'livingType': livingType,
+    };
+  }
+}
+
+/// 初回ユーザー登録のレスポンス情報
+class UserRegisterResponse {
+  final String userId;
+  final String userName;
+  final int birthDate;
+  final String livingType;
+
+  UserRegisterResponse({
+    required this.userId,
+    required this.userName,
+    required this.birthDate,
+    required this.livingType,
+  });
+
+  /// JSON → UserRegisterResponse
+  factory UserRegisterResponse.fromJson(Map<String, dynamic> json) {
+    return UserRegisterResponse(
+      userId: json['userId'] ?? '',
+      userName: json['userName'] ?? '',
+      birthDate: json['birthDate'] ?? 0,
+      livingType: json['livingType'] ?? '',
+    );
+  }
+}

--- a/lib/services/user/user_register_service.dart
+++ b/lib/services/user/user_register_service.dart
@@ -1,0 +1,52 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+
+import '../../constants/app_config.dart';
+import '../../models/user_lifestyle_info.dart';
+import '../../models/user_register_info.dart';
+import '../auth_manager.dart';
+
+/// 初回ユーザー登録・生活環境情報登録を行うサービス
+///
+/// アクセストークンが必須のため、`AuthManager.authenticatedRequest` を使用して
+/// Authorizationヘッダーにアクセストークンを付与して通信する
+class UserRegisterService {
+  /// 初回ユーザー登録
+  Future<UserRegisterResponse> registerUser(UserRegisterRequest request) async {
+    final response = await AuthManager.authenticatedRequest(
+      AppConfig.userRegisterEndpoint,
+      method: 'POST',
+      body: request.toJson(),
+    );
+
+    /// 通信成功
+    if (response.statusCode == 200) {
+      final Map<String, dynamic> jsonData = jsonDecode(response.body);
+      return UserRegisterResponse.fromJson(jsonData);
+    }
+
+    /// 通信失敗
+    debugPrint('初回ユーザー登録失敗: ${response.statusCode} - ${response.body}');
+    throw Exception('初回ユーザー登録失敗');
+  }
+
+  /// 生活環境情報の登録（初回）
+  Future<UserLifestyleInfo> registerLifestyle(UserLifestyleInfo lifestyle) async {
+    final response = await AuthManager.authenticatedRequest(
+      AppConfig.userLifestyleEndpoint,
+      method: 'POST',
+      body: lifestyle.toJson(),
+    );
+
+    /// 通信成功
+    if (response.statusCode == 200) {
+      final Map<String, dynamic> jsonData = jsonDecode(response.body);
+      return UserLifestyleInfo.fromJson(jsonData);
+    }
+
+    /// 通信失敗
+    debugPrint('生活環境情報登録失敗: ${response.statusCode} - ${response.body}');
+    throw Exception('生活環境情報登録失敗');
+  }
+}

--- a/lib/services/user/user_register_service.dart
+++ b/lib/services/user/user_register_service.dart
@@ -14,11 +14,15 @@ import '../auth_manager.dart';
 class UserRegisterService {
   /// 初回ユーザー登録
   Future<UserRegisterResponse> registerUser(UserRegisterRequest request) async {
+    debugPrint('🚀 初回ユーザー登録リクエスト: ${AppConfig.userRegisterEndpoint} - ${jsonEncode(request.toJson())}');
+
     final response = await AuthManager.authenticatedRequest(
       AppConfig.userRegisterEndpoint,
       method: 'POST',
       body: request.toJson(),
     );
+
+    debugPrint('🔍 初回ユーザー登録レスポンス: ${response.statusCode} - ${response.body}');
 
     /// 通信成功
     if (response.statusCode == 200) {
@@ -27,17 +31,21 @@ class UserRegisterService {
     }
 
     /// 通信失敗
-    debugPrint('初回ユーザー登録失敗: ${response.statusCode} - ${response.body}');
+    debugPrint('❌ 初回ユーザー登録失敗: ${response.statusCode} - ${response.body}');
     throw Exception('初回ユーザー登録失敗');
   }
 
   /// 生活環境情報の登録（初回）
   Future<UserLifestyleInfo> registerLifestyle(UserLifestyleInfo lifestyle) async {
+    debugPrint('🚀 生活環境情報登録リクエスト: ${AppConfig.userLifestyleEndpoint} - ${jsonEncode(lifestyle.toJson())}');
+
     final response = await AuthManager.authenticatedRequest(
       AppConfig.userLifestyleEndpoint,
       method: 'POST',
       body: lifestyle.toJson(),
     );
+
+    debugPrint('🔍 生活環境情報登録レスポンス: ${response.statusCode} - ${response.body}');
 
     /// 通信成功
     if (response.statusCode == 200) {
@@ -46,7 +54,7 @@ class UserRegisterService {
     }
 
     /// 通信失敗
-    debugPrint('生活環境情報登録失敗: ${response.statusCode} - ${response.body}');
+    debugPrint('❌ 生活環境情報登録失敗: ${response.statusCode} - ${response.body}');
     throw Exception('生活環境情報登録失敗');
   }
 }

--- a/lib/services/user/user_register_service.dart
+++ b/lib/services/user/user_register_service.dart
@@ -14,7 +14,7 @@ import '../auth_manager.dart';
 class UserRegisterService {
   /// 初回ユーザー登録
   Future<UserRegisterResponse> registerUser(UserRegisterRequest request) async {
-    debugPrint('🚀 初回ユーザー登録リクエスト: ${AppConfig.userRegisterEndpoint} - ${jsonEncode(request.toJson())}');
+    debugPrint('初回ユーザー登録リクエスト: ${AppConfig.userRegisterEndpoint} - ${jsonEncode(request.toJson())}');
 
     final response = await AuthManager.authenticatedRequest(
       AppConfig.userRegisterEndpoint,
@@ -22,7 +22,7 @@ class UserRegisterService {
       body: request.toJson(),
     );
 
-    debugPrint('🔍 初回ユーザー登録レスポンス: ${response.statusCode} - ${response.body}');
+    debugPrint('初回ユーザー登録レスポンス: ${response.statusCode} - ${response.body}');
 
     /// 通信成功
     if (response.statusCode == 200) {
@@ -31,13 +31,13 @@ class UserRegisterService {
     }
 
     /// 通信失敗
-    debugPrint('❌ 初回ユーザー登録失敗: ${response.statusCode} - ${response.body}');
+    debugPrint('初回ユーザー登録失敗: ${response.statusCode} - ${response.body}');
     throw Exception('初回ユーザー登録失敗');
   }
 
   /// 生活環境情報の登録（初回）
   Future<UserLifestyleInfo> registerLifestyle(UserLifestyleInfo lifestyle) async {
-    debugPrint('🚀 生活環境情報登録リクエスト: ${AppConfig.userLifestyleEndpoint} - ${jsonEncode(lifestyle.toJson())}');
+    debugPrint('生活環境情報登録リクエスト: ${AppConfig.userLifestyleEndpoint} - ${jsonEncode(lifestyle.toJson())}');
 
     final response = await AuthManager.authenticatedRequest(
       AppConfig.userLifestyleEndpoint,
@@ -45,7 +45,7 @@ class UserRegisterService {
       body: lifestyle.toJson(),
     );
 
-    debugPrint('🔍 生活環境情報登録レスポンス: ${response.statusCode} - ${response.body}');
+    debugPrint('生活環境情報登録レスポンス: ${response.statusCode} - ${response.body}');
 
     /// 通信成功
     if (response.statusCode == 200) {
@@ -54,7 +54,7 @@ class UserRegisterService {
     }
 
     /// 通信失敗
-    debugPrint('❌ 生活環境情報登録失敗: ${response.statusCode} - ${response.body}');
+    debugPrint('生活環境情報登録失敗: ${response.statusCode} - ${response.body}');
     throw Exception('生活環境情報登録失敗');
   }
 }

--- a/lib/views/splash/login/login_splash_screen.dart
+++ b/lib/views/splash/login/login_splash_screen.dart
@@ -66,7 +66,7 @@ late String currentMessage;
 
   /// 初回ユーザー登録・生活環境情報登録を行い、完了後にホームへ遷移する
   Future<void> _registerUserAndGoNext() async {
-    debugPrint('🚀 初回ユーザー登録処理を開始します');
+    debugPrint('初回ユーザー登録処理を開始します');
 
     try {
       // ① 初回ユーザー登録
@@ -75,9 +75,9 @@ late String currentMessage;
       // ② 生活環境情報の登録
       await _registerService.registerLifestyle(widget.lifestyleInfo);
 
-      debugPrint('✅ 初回ユーザー登録処理が完了しました');
+      debugPrint('初回ユーザー登録処理が完了しました');
     } catch (e) {
-      debugPrint('❌ 初回ユーザー登録処理でエラーが発生しました: $e');
+      debugPrint('初回ユーザー登録処理でエラーが発生しました: $e');
     }
 
     _goNext();

--- a/lib/views/splash/login/login_splash_screen.dart
+++ b/lib/views/splash/login/login_splash_screen.dart
@@ -2,11 +2,38 @@ import 'package:flutter/material.dart';
 import 'dart:async';
 import 'dart:math';
 import '../../../components/colors.dart';
+import '../../../models/user_lifestyle_info.dart';
+import '../../../models/user_register_info.dart';
+import '../../../services/user/user_register_service.dart';
 import './chara_massages.dart';
 import '../../app.dart';
 
 class LoginSplashScreen extends StatefulWidget {
-  const LoginSplashScreen({super.key});
+  // TODO: 生活環境情報アンケート画面が実装され次第、呼び出し元から実際の入力値を渡すようにする
+  /// 初回ユーザー登録リクエスト
+  final UserRegisterRequest registerRequest;
+
+  /// 生活環境情報
+  final UserLifestyleInfo lifestyleInfo;
+
+  LoginSplashScreen({
+    super.key,
+    UserRegisterRequest? registerRequest,
+    UserLifestyleInfo? lifestyleInfo,
+  })  : registerRequest = registerRequest ??
+            UserRegisterRequest(
+              birthDate: 946684800,
+              livingType: 'alone',
+            ),
+        lifestyleInfo = lifestyleInfo ??
+            UserLifestyleInfo(
+              isAlone: true,
+              hasWasher: true,
+              hasVacuum: false,
+              hasRobot: true,
+              useTableware: true,
+              hasDishwasher: true,
+            );
 
   @override
   State<LoginSplashScreen> createState() => _LoginSplashScreenState();
@@ -21,6 +48,9 @@ class _LoginSplashScreenState extends State<LoginSplashScreen> {
 
 late String currentMessage;
 
+  /// 初回ユーザー登録・生活環境情報登録を行うサービス
+  final _registerService = UserRegisterService();
+
   @override
   void initState() {
     super.initState();
@@ -29,6 +59,23 @@ late String currentMessage;
 
     _startAnimation();
     _startMilkFloat();
+
+    // ローディング中に初回登録APIを呼び出してからホームへ遷移する
+    _registerUserAndGoNext();
+  }
+
+  /// 初回ユーザー登録・生活環境情報登録を行い、完了後にホームへ遷移する
+  Future<void> _registerUserAndGoNext() async {
+    try {
+      // ① 初回ユーザー登録
+      await _registerService.registerUser(widget.registerRequest);
+
+      // ② 生活環境情報の登録
+      await _registerService.registerLifestyle(widget.lifestyleInfo);
+    } catch (e) {
+      debugPrint('初回ユーザー登録処理でエラーが発生しました: $e');
+    }
+
     _goNext();
   }
 

--- a/lib/views/splash/login/login_splash_screen.dart
+++ b/lib/views/splash/login/login_splash_screen.dart
@@ -66,14 +66,18 @@ late String currentMessage;
 
   /// 初回ユーザー登録・生活環境情報登録を行い、完了後にホームへ遷移する
   Future<void> _registerUserAndGoNext() async {
+    debugPrint('🚀 初回ユーザー登録処理を開始します');
+
     try {
       // ① 初回ユーザー登録
       await _registerService.registerUser(widget.registerRequest);
 
       // ② 生活環境情報の登録
       await _registerService.registerLifestyle(widget.lifestyleInfo);
+
+      debugPrint('✅ 初回ユーザー登録処理が完了しました');
     } catch (e) {
-      debugPrint('初回ユーザー登録処理でエラーが発生しました: $e');
+      debugPrint('❌ 初回ユーザー登録処理でエラーが発生しました: $e');
     }
 
     _goNext();


### PR DESCRIPTION
## 🎉✨ Summary 🚀🔥
- 🎊🌟 ログイン後のローディング画面（LoginSplashScreen）で、アクセストークンをAuthorizationヘッダーに付与しながら `POST /app/user/register` 🆕 と `POST /app/user/lifestyle` 🏠💧 を順に呼び出す処理を追加！！🎉🎉
- 📝📋🔍 各APIコールの前後にログ出力を追加（リクエスト内容、レスポンス、成功✅/失敗❌）💯

## 🛠️🔧 変更内容 ⚙️✅
- 🗺️📍 `AppConfig` に `/app/user/register` 👤, `/app/user/lifestyle` 🏡 のエンドポイントを追加🆙
- 🧩📦 `UserRegisterRequest` / `UserRegisterResponse` / `UserLifestyleInfo` モデルを新規作成🌈✨
- 🏗️🔨 `UserRegisterService` を新規作成し、既存の `AuthManager.authenticatedRequest`🔑🛡️（アクセストークン自動取得・付与）を利用して本番🚨環境へPOST通信📡
- 🎬🖼️ `LoginSplashScreen` で、アニメーション開始後に①ユーザー登録🙋→②生活環境情報登録🏠の順でAPIを呼び出し、完了🏁後に従来通りホーム🏡画面へ遷移するよう変更🔀

## 🚧⚠️ 未対応（今後の課題）📌🗒️
- 🙅‍♂️❓ 生活環境情報を入力するアンケート画面📝がまだ存在しないため、`LoginSplashScreen` の引数として値を渡せるようにし、未指定時は仮😅のデフォルト値を使用
- 🔁♾️ 既に初回登録済みのユーザーが再ログインした場合でも毎回登録APIが呼ばれてしまう点は今回のスコープ外🙏

## ✅🧪 Test plan 🔬📐
- [x] 🕵️‍♂️💻 `flutter analyze` でエラー・警告がないことを確認済み🎯
- [ ] 📱🖥️ 実機/シミュレータでログイン→ローディング画面→ホーム画面への遷移を確認👀
- [ ] 📊📄 APIレスポンスのログが正しく出力されることを確認🖨️